### PR TITLE
Fixes focusout event functionality to exit text area when return key …

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,7 +29,7 @@ btnSave.addEventListener('click', addIdea);
 // btnSwill.addEventListener('click', );
 // cardArea.addEventListener('click', deleteCard);
 cardArea.addEventListener('focusout', handleFocusOut);
-cardArea.addEventListener('keyup', handleTextEdit);
+cardArea.addEventListener('keydown', handleTextEdit);
 cardArea.addEventListener('click', handleCardButtons);
 inputTitle.addEventListener('keyup', handleSaveBtn);
 inputBody.addEventListener('keyup', handleSaveBtn);
@@ -120,7 +120,7 @@ function handleFocusOut(e) {
 }
 
 function handleTextEdit(e) {
-  if (e.key === 13) {
+  if (e.key === 'Enter') {
     e.target.blur();
     console.log("event:", event);
     var newTitle = e.target.closest('.card-content').querySelector('.card-title').innerText;


### PR DESCRIPTION
…event is detected

Return key code 13 was saving the edited text but was adding an additional line. It has now been updated so that when the return key is detected the text area input is blurred and no additional line is added.